### PR TITLE
use golang docker image to build singularity + optimize multi-stage

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,46 +1,48 @@
-FROM dorowu/ubuntu-desktop-lxde-vnc:bionic AS desktop
-# based on this wonderful work https://github.com/fcwu/docker-ubuntu-vnc-desktop
+ARG GO_VERSION="1.14.4"
+ARG SINGULARITY_VERSION="3.5.3"
 
-# =====================================================================================
-# INSTALL SINGULARITY
-# =====================================================================================
+# Build Singularity.
+FROM golang:${GO_VERSION}-buster as builder
 
-# Install binary dependencies
+# Necessary to pass the arg from outside this build (it is defined before the FROM).
+ARG SINGULARITY_VERSION
+
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
-        build-essential \
+        cryptsetup \
         libssl-dev \
         uuid-dev \
-        libseccomp-dev \
-        pkg-config \
-        squashfs-tools \
-        cryptsetup \
     && rm -rf /var/lib/apt/lists/*
 
-# Build Go and Singularity
-FROM desktop as install-singularity
-
-WORKDIR /tmp
-
-ENV GO_VERS=1.14.4 \
-    SINGULARITY_VERS=3.5.3
-
-RUN curl -SLO "https://dl.google.com/go/go${GO_VERS}.linux-amd64.tar.gz" \
-    && tar --strip 1 -C /usr/local -xzf "go${GO_VERS}.linux-amd64.tar.gz" \
-    && rm -rf go*
-
-RUN curl -SLO "https://github.com/hpcng/singularity/releases/download/v${SINGULARITY_VERS}/singularity-${SINGULARITY_VERS}.tar.gz" \
-    && tar -xzf "singularity-${SINGULARITY_VERS}.tar.gz" \
+RUN curl -fsSL "https://github.com/hpcng/singularity/releases/download/v${SINGULARITY_VERSION}/singularity-${SINGULARITY_VERSION}.tar.gz" \
+    | tar -xz \
     && cd singularity \
-    && ./mconfig -p /usr/local \
+    && ./mconfig -p /usr/local/singularity \
     && cd builddir \
     && make \
-    && make install \
-    && rm -rf singularity*
+    && make install
 
-# Install Singularity
-FROM desktop as runner
 
-COPY --from=install-singularity /usr/local /usr/local
+# Create final image.
+# Based on this wonderful work https://github.com/fcwu/docker-ubuntu-vnc-desktop
+FROM dorowu/ubuntu-desktop-lxde-vnc:bionic
+
+# Install singularity into the final image.
+COPY --from=builder /usr/local/singularity /usr/local/singularity
+
+# Install singularity's runtime dependencies.
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        cryptsetup \
+        squashfs-tools \
+    && rm -rf /var/lib/apt/lists/*
+
+# Necessary to pass the args from outside this build (it is defined before the FROM).
+ARG GO_VERSION
+ARG SINGULARITY_VERSION
+
+ENV PATH="/usr/local/singularity/bin:$PATH" \
+    GO_VERSION=$GO_VERSION \
+    SINGULARITY_VERSION=$SINGULARITY_VERSION
 
 WORKDIR /vnm


### PR DESCRIPTION
The description advertises a compact docker image, but it is almost 2 gigabytes :) This PR reduces the image size by about 500 MB. The Dockerfile uses the official golang docker image to build singularity. The final image before this PR included `build-essential` packages, so the installation of compile-time dependencies was moved inside the build stage of the dockerfile.