### PR TITLE
Add terminal shortcut to Application Launchbar using a custom panel

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -45,4 +45,6 @@ ENV PATH="/usr/local/singularity/bin:$PATH" \
     GO_VERSION=$GO_VERSION \
     SINGULARITY_VERSION=$SINGULARITY_VERSION
 
+COPY ./menus/panel /home/neuro/.config/lxpanel/LXDE/panels/panel
+
 WORKDIR /vnm

--- a/menus/panel
+++ b/menus/panel
@@ -1,0 +1,140 @@
+# lxpanel <profile> config file. Manually editing is not recommended.
+# Use preference dialog in lxpanel to adjust config when you can.
+
+Global {
+  edge=bottom
+  align=left
+  margin=0
+  widthtype=percent
+  width=100
+  height=26
+  transparent=0
+  tintcolor=#000000
+  alpha=0
+  setdocktype=1
+  setpartialstrut=1
+  autohide=0
+  heightwhenhidden=0
+  usefontcolor=1
+  fontcolor=#ffffff
+  background=1
+  backgroundfile=/usr/share/lxpanel/images/background.png
+}
+Plugin {
+  type=space
+  Config {
+    Size=2
+  }
+}
+Plugin {
+  type=menu
+  Config {
+    image=/usr/share/lxde/images/lxde-icon.png
+    system {
+    }
+    separator {
+    }
+    item {
+      command=run
+    }
+    separator {
+    }
+    item {
+      image=gnome-logout
+      command=logout
+    }
+  }
+}
+Plugin {
+  type=launchbar
+  Config {
+    Button {
+      id=pcmanfm.desktop
+    }
+    Button {
+      id=lxde-x-www-browser.desktop
+    }
+    Button {
+      id=lxterminal.desktop
+    }
+  }
+}
+Plugin {
+  type=space
+  Config {
+    Size=4
+  }
+}
+Plugin {
+  type=wincmd
+  Config {
+    Button1=iconify
+    Button2=shade
+      }
+}
+Plugin {
+  type=space
+  Config {
+    Size=4
+  }
+}
+Plugin {
+  type=pager
+  Config {
+  }
+}
+Plugin {
+  type=space
+  Config {
+    Size=4
+  }
+}
+Plugin {
+  type=taskbar
+  expand=1
+  Config {
+    tooltips=1
+    IconsOnly=0
+    AcceptSkipPager=1
+    ShowIconified=1
+    ShowMapped=1
+    ShowAllDesks=0
+    UseMouseWheel=1
+    UseUrgencyHint=1
+    FlatButton=0
+    MaxTaskWidth=150
+    spacing=1
+  }
+}
+Plugin {
+  type=cpu
+  Config {
+  }
+}
+Plugin {
+  type=tray
+  Config {
+  }
+}
+Plugin {
+  type=dclock
+  Config {
+    ClockFmt=%R
+    TooltipFmt=%A %x
+    BoldFont=0
+    IconOnly=0
+    CenterText=0
+  }
+}
+Plugin {
+  type=launchbar
+  Config {
+    Button {
+      id=lxde-screenlock.desktop
+    }
+    Button {
+      id=lxde-logout.desktop
+    }
+  }
+}
+


### PR DESCRIPTION
LXDE panel config is at ~/.config/lxpanel/LXDE/panels/panel
**panel file will be missing on desktop startup, you have to open "Panel Settings" GUI to initialize it

This modified panel file has the terminal app added
app shortcuts are configured under /usr/share/applications