### PR TITLE
.gitattributes for forcing LF endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,9 @@
 # Forcing UNIX LF line endings for text files added to container
-./scripts/*.sh text eol=lf
-./menus/panel text eol=lf
-./menus/lxde-applications.menu text eol=lf
-./menus/vnm-applications.menu text eol=lf
-./menus/submenus/*.directory text eol=lf
-./menus/applications/*.desktop text eol=lf
+# ./scripts/*.sh text eol=lf
+# ./menus/panel text eol=lf
+# ./menus/lxde-applications.menu text eol=lf
+# ./menus/vnm-applications.menu text eol=lf
+# ./menus/submenus/*.directory text eol=lf
+# ./menus/applications/*.desktop text eol=lf
+
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,7 @@
 # Forcing UNIX LF line endings for text files added to container
-# ./scripts/*.sh text eol=lf
-# ./menus/panel text eol=lf
-# ./menus/lxde-applications.menu text eol=lf
-# ./menus/vnm-applications.menu text eol=lf
-# ./menus/submenus/*.directory text eol=lf
-# ./menus/applications/*.desktop text eol=lf
-
-*.sh text eol=lf
+./scripts/*.sh text eol=lf
+./menus/panel text eol=lf
+./menus/lxde-applications.menu text eol=lf
+./menus/vnm-applications.menu text eol=lf
+./menus/submenus/*.directory text eol=lf
+./menus/applications/*.desktop text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Forcing UNIX LF line endings for text files added to container
+./scripts/*.sh text eol=lf
+./menus/panel text eol=lf
+./menus/lxde-applications.menu text eol=lf
+./menus/vnm-applications.menu text eol=lf
+./menus/submenus/*.directory text eol=lf
+./menus/applications/*.desktop text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 # Forcing UNIX LF line endings for text files added to container
-./scripts/*.sh text eol=lf
-./menus/panel text eol=lf
-./menus/lxde-applications.menu text eol=lf
-./menus/vnm-applications.menu text eol=lf
-./menus/submenus/*.directory text eol=lf
-./menus/applications/*.desktop text eol=lf
+scripts/*.sh text eol=lf
+menus/panel text eol=lf
+menus/lxde-applications.menu text eol=lf
+menus/vnm-applications.menu text eol=lf
+menus/submenus/*.directory text eol=lf
+menus/applications/*.desktop text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,6 @@ RUN apt-get update \
         lua-term \
         lua5.2 \
         lmod \
-        dos2unix \
         git \
     && rm -rf /var/lib/apt/lists/*
 
@@ -71,12 +70,9 @@ ENV PATH="/usr/local/singularity/bin:${PATH}" \
 
 # add custom scripts
 COPY ./scripts/* /usr/share/
-# RUN dos2unix /usr/share/*
 
 # Use custom bottom panel configuration
 COPY ./menus/panel /home/${LINUX_USER_NAME}/.config/lxpanel/LXDE/panels/panel
-# RUN dos2unix /home/${LINUX_USER_NAME}/.config/lxpanel/LXDE/panels/panel
-
 
 # Application and submenu icons
 RUN mkdir -p /home/${LINUX_USER_NAME}/.config/lxpanel/LXDE/icons
@@ -87,23 +83,16 @@ RUN chmod 644 /home/${LINUX_USER_NAME}/.config/lxpanel/LXDE/icons/*
 
 # Main-menu config. Add Menu changes to vnm-applications.menu
 COPY ./menus/lxde-applications.menu /etc/xdg/menus/
-RUN dos2unix /etc/xdg/menus/lxde-applications.menu
 COPY ./menus/vnm-applications.menu /etc/xdg/menus/
-# RUN dos2unix /etc/xdg/menus/vnm-applications.menu
 
 RUN chmod 644 /etc/xdg/menus/lxde-applications.menu
 
 # Sub-menu configs
 COPY ./menus/submenus/*.directory /usr/share/desktop-directories/
 RUN chmod 644 /usr/share/desktop-directories/*.directory
-# RUN dos2unix /usr/share/desktop-directories/*.directory
 
 # Application configs
 COPY ./menus/applications/*.desktop /usr/share/applications/
 RUN chmod 644 /usr/share/applications/*
-# RUN dos2unix /usr/share/applications/*
 
 WORKDIR /vnm
-
-# cleanup dos2unix tool
-RUN apt-get --purge remove -y dos2unix && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,11 +71,11 @@ ENV PATH="/usr/local/singularity/bin:${PATH}" \
 
 # add custom scripts
 COPY ./scripts/* /usr/share/
-RUN dos2unix /usr/share/*
+# RUN dos2unix /usr/share/*
 
 # Use custom bottom panel configuration
 COPY ./menus/panel /home/${LINUX_USER_NAME}/.config/lxpanel/LXDE/panels/panel
-RUN dos2unix /home/${LINUX_USER_NAME}/.config/lxpanel/LXDE/panels/panel
+# RUN dos2unix /home/${LINUX_USER_NAME}/.config/lxpanel/LXDE/panels/panel
 
 
 # Application and submenu icons
@@ -89,19 +89,19 @@ RUN chmod 644 /home/${LINUX_USER_NAME}/.config/lxpanel/LXDE/icons/*
 COPY ./menus/lxde-applications.menu /etc/xdg/menus/
 RUN dos2unix /etc/xdg/menus/lxde-applications.menu
 COPY ./menus/vnm-applications.menu /etc/xdg/menus/
-RUN dos2unix /etc/xdg/menus/vnm-applications.menu
+# RUN dos2unix /etc/xdg/menus/vnm-applications.menu
 
 RUN chmod 644 /etc/xdg/menus/lxde-applications.menu
 
 # Sub-menu configs
 COPY ./menus/submenus/*.directory /usr/share/desktop-directories/
 RUN chmod 644 /usr/share/desktop-directories/*.directory
-RUN dos2unix /usr/share/desktop-directories/*.directory
+# RUN dos2unix /usr/share/desktop-directories/*.directory
 
 # Application configs
 COPY ./menus/applications/*.desktop /usr/share/applications/
 RUN chmod 644 /usr/share/applications/*
-RUN dos2unix /usr/share/applications/*
+# RUN dos2unix /usr/share/applications/*
 
 WORKDIR /vnm
 


### PR DESCRIPTION
.gitattributes solution for forcing LF endings on unix files. Removed dos2unix.

New clones should work.
Already cloned repos may need to clear their cached files after pulling these changes..
Use the following to clear git cache
```
git rm --cached -r .
git reset --hard
```